### PR TITLE
fix: Remove ArcGIS API for JavaScript & Add ArcGIS Maps SDK for JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 Libraries for creating web maps:
 
 - [Leaflet](https://leafletjs.com/) - The leading open-source JavaScript library for mobile-friendly interactive maps.
+- [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/) - Modern JavaScript API and web component library for building interactive web apps for the browser.
 - [OpenLayers](https://openlayers.org/) - A high-performance, feature-packed library for creating interactive maps on the web.
 - [Cesium.js](https://cesium.com) - An open-source JavaScript library for world-class 3D mapping of geospatial data.
 - [maplibre](https://github.com/maplibre/maplibre-gl-js) - It originated as an open-source fork of mapbox-gl-js, before their switch to a non-OSS license in December 2020.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Libraries for creating web maps:
 - [Google Maps](https://developers.google.com/maps/documentation/javascript) - Google Maps API for JavaScript.
 - [Wrld.js](https://github.com/wrld3d/wrld.js/) - Animated 3D city maps based on Leaflet.
 - [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/examples/) - JavaScript library that uses WebGL to render interactive maps from vector tiles.
-- [ArcGIS API for JS](https://developers.arcgis.com/javascript/3/) - A lightweight way to embed maps and tasks in web applications.
 - [HERE maps API](https://developer.here.com/develop/javascript-api) - Build web applications with feature-rich and customizable HERE maps.
 - [Map Forecast API](https://github.com/windycom/API) - Simple-to-use library based on Leaflet 1.4.x. It allows you to show wind maps.
 


### PR DESCRIPTION
ArcGIS API for JavaScript Version 3.x retired on July 1, 2024. Version 3.46 was the final release of the 3.x series. For more details, see the [[retirement announcement](https://www.esri.com/arcgis-blog/products/js-api-arcgis/developers/arcgis-api-for-javascript-version-3-x-retirement/)](https://www.esri.com/arcgis-blog/products/js-api-arcgis/developers/arcgis-api-for-javascript-version-3-x-retirement/).

This fix adds ArcGIS Maps SDK for JavaScript, the 4.x version of Esri's ArcGIS JavaScript API. It addresses issues #6 and #7.