### PR TITLE
Add halfmaps to web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Plug-and-play geospatial web apps:
 - [Datawrapper](https://github.com/datawrapper/datawrapper) - Create charts, maps, and tables.
 - [Fantasy Map Generator](https://github.com/Azgaar/Fantasy-Map-Generator) - Free web application for creating and editing fantasy maps.
 - [geotiff.io](http://app.geotiff.io/) - Provides quick access to easy-to-use raster processing.
+- [halfmaps](https://www.halfmaps.io/) - 3D map exporter that converts geospatial data into models for CAD, GIS, and 3D workflows.
 - [IMAGE](https://gisco-services.ec.europa.eu/image/) - Tool for generating thematic maps.
 - [Kepler](https://kepler.gl/demo) - A powerful open-source geospatial analysis tool for large-scale datasets.
 - [magrit](https://magrit.cnrs.fr/) - An online application for thematic mapping.


### PR DESCRIPTION
Add [halfmaps](https://www.halfmaps.io/) a 3D map exporter that converts real-world geospatial data into models for CAD, GIS, and 3D workflows, with export formats like GLTF, OBJ, STL, and 3MF