### PR TITLE
Add CoordinateMapper - free coordinate conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Plug-and-play geospatial web apps:
 - [GeoJSONLint](https://geojsonlint.com/) - Use this site to validate and view your GeoJSON.
 - [Pharos AI](https://conflicts.app) - Open-source real-time intelligence dashboard for geopolitical conflict tracking with interactive DeckGL/MapLibre geospatial visualization. ([Source Code](https://github.com/Juliusolsson05/pharos-ai)) ![GitHub stars](https://img.shields.io/github/stars/Juliusolsson05/pharos-ai?style=social)
 - [Pumperly](https://github.com/GeiserX/pumperly) - Open-source fuel price comparison and EV charging route planner using MapLibre GL JS, PostGIS, Valhalla routing, and Photon geocoding. ![GitHub stars](https://img.shields.io/github/stars/GeiserX/pumperly?style=social)
-
+- [CoordinateMapper](https://coordinatemapper.com/) - Free browser-based tool for converting between lat/long, UTM, UK Grid References, Easting/Northing, MGRS, DMS and DDM. Includes map preview and CSV/KML/DXF export.
 
 ## 🎨 Colour advice 
 Colour usage is very important in data visualisation and cartography. Here are some tools to help you choose the best colours for your maps:


### PR DESCRIPTION
CoordinateMapper is a free browser-based tool that converts coordinates between all major formats, lat/long (DD, DMS, DDM), UTM, UK Grid References, Easting/Northing and MGRS across both WGS84 and OSGB36 datums. Paste any coordinate, verify it on the live map, and export to CSV, KML or DXF. Also includes an extensive library of guides and troubleshooting resources covering coordinate systems, datums, projections and common conversion errors. No sign-up, no limits.