### PR TITLE
Add Kano geospatial web application

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Plug-and-play geospatial web apps:
 - [GeoJSONLint](https://geojsonlint.com/) - Use this site to validate and view your GeoJSON.
 - [Pharos AI](https://conflicts.app) - Open-source real-time intelligence dashboard for geopolitical conflict tracking with interactive DeckGL/MapLibre geospatial visualization. ([Source Code](https://github.com/Juliusolsson05/pharos-ai)) ![GitHub stars](https://img.shields.io/github/stars/Juliusolsson05/pharos-ai?style=social)
 - [Pumperly](https://github.com/GeiserX/pumperly) - Open-source fuel price comparison and EV charging route planner using MapLibre GL JS, PostGIS, Valhalla routing, and Photon geocoding. ![GitHub stars](https://img.shields.io/github/stars/GeiserX/pumperly?style=social)
+- [Kano](https://github.com/kalisio/kano) - Open-source web application for visualising geospatial data from OGC-compliant services, combining Leaflet and Cesium.js. ![GitHub stars](https://img.shields.io/github/stars/kalisio/kano?style=social)
 
 
 ## 🎨 Colour advice 


### PR DESCRIPTION
Adds [Kano](https://github.com/kalisio/kano) to the Web apps section.

Kano is an open-source web application for visualising geospatial data from OGC-compliant services (WMS, WMTS, WFS, WCS), combining Leaflet and Cesium.js for 2D/3D rendering. It has been actively maintained since 2017 and is MIT-licensed.