### PR TITLE
Add Zip-Codes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Restful APIs for consuming geospatial data on the fly:
 - [Sunrise and sunset](https://sunrise-sunset.org) - Provides sunset and sunrise times for locations.
 - [TomTom](https://developer.tomtom.com/api-explorer-index/documentation/product-information/introduction) - Geocoding, routing, traffic, and more.
 - [USGS earthquake data](https://earthquake.usgs.gov/fdsnws/event/1/) - Search earthquake data by various parameters.
+- [Zip-Codes](https://www.zip-codes.com/api/) - US and Canadian postal code data with address validation, radius search, demographics, and boundaries.
 - [ZipCheckup API](https://github.com/artakulov/us-water-quality-data) - Free REST API for US ZIP-level environmental safety data: water quality, air quality, PFAS, radon, lead, flood risk. ![GitHub stars](https://img.shields.io/github/stars/artakulov/us-water-quality-data?style=social)
 - [what3words](https://developer.what3words.com/public-api) - Converts 3-word addresses to coordinates.
 


### PR DESCRIPTION
  Adds Zip-Codes to the Web APIs section under Data sources.

  Hosted REST API for US ZIP, ZIP+4, and Canadian postal codes. Covers address parsing/standardization, radius search
  (centroid and spatial polygon), point-to-point distance, autocomplete/typeahead, demographics (Census ACS 2011–2024),
  and boundaries.

  Format note: I noticed CONTRIBUTING.md prefers open source, but the Web APIs section already includes commercial APIs
  (OpenCage, what3words, Address API). Including in that spirit — happy to revise or withdraw if this doesn't fit.

  - Docs: https://api.zip-codes.com/docs
  - OpenAPI: https://api.zip-codes.com/v2/openapi.json
  - Free tier: 2,500 lookups/day, no credit card