### PR TITLE
Add Leaves.PH to Web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Plug-and-play geospatial web apps:
 - [GeoJSONLint](https://geojsonlint.com/) - Use this site to validate and view your GeoJSON.
 - [Pharos AI](https://conflicts.app) - Open-source real-time intelligence dashboard for geopolitical conflict tracking with interactive DeckGL/MapLibre geospatial visualization. ([Source Code](https://github.com/Juliusolsson05/pharos-ai)) ![GitHub stars](https://img.shields.io/github/stars/Juliusolsson05/pharos-ai?style=social)
 - [Pumperly](https://github.com/GeiserX/pumperly) - Open-source fuel price comparison and EV charging route planner using MapLibre GL JS, PostGIS, Valhalla routing, and Photon geocoding. ![GitHub stars](https://img.shields.io/github/stars/GeiserX/pumperly?style=social)
+- [Leaves.PH](https://leaves.ph) - Interactive map of Metro Manila's tree canopy from Sentinel-2 satellite imagery, with annual per-LGU and per-barangay values from 2019 to 2026. ([Source Code](https://github.com/xmpuspus/leaves-ph))
 
 
 ## 🎨 Colour advice 


### PR DESCRIPTION
Adding [Leaves.PH](https://leaves.ph) to the Web apps section.

An open-source interactive web map of Metro Manila's tree canopy measured from Sentinel-2 satellite imagery, with annual per-LGU and per-barangay values from 2019 to 2026 (vector tiles, year slider). Open and reproducible. Source: https://github.com/xmpuspus/leaves-ph

One entry added to the bottom of the Web apps list following the existing format.