### PR TITLE
feat: add TWZRD Agent Intel to Web APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Data available for download:
 Restful APIs for consuming geospatial data on the fly:
 
 - [Address API](https://gisco-services.ec.europa.eu/addressapi/docs/) - Pan-European address data with geocoding and reverse-geocoding.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agents on Solana. Verify agent wallet identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [API Geo](https://geo.api.gouv.fr/) - Official French geographical data API.
 - [ArcGIS location services](https://developers.arcgis.com/rest/location-based-services/) - Basemaps, Geocoding, Places, routing, and GeoEnrichment.
 - [bng2latlong](https://www.getthedata.com/bng2latlong) - Converts British National Grid to latitude and longitude.


### PR DESCRIPTION
Adds TWZRD Agent Intel — a trust scoring MCP server for AI agents on Solana with x402 micropayment support.

**URL**: https://intel.twzrd.xyz

**MCP Config**:
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Fits in the Web APIs section as a geospatial-adjacent agent verification API — autonomous agents querying geospatial APIs can use TWZRD to verify trust receipts before making x402 micropayments for premium location data. Free tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt.