### PR TITLE
Add Mapbase to geospatial resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Restful APIs for consuming geospatial data on the fly:
 - [Geocode.xyz](https://geocode.xyz/) - Reverse geocoding, forward geocoding, and geoparsing API.
 - [GISCO data distribution API](https://gisco-services.ec.europa.eu/distribution/v2/) - European Commission data source for administrative regions and boundaries.
 - [GraphHopper Route Optimization API](https://www.graphhopper.com/route-optimization/) - Solves various vehicle routing problems.
+- [Mapbase](https://mapbase.dev/) - Location registry API that turns coordinates into official locations, custom zones, hierarchy, geometry, and SEO-ready location context. Includes autocomplete, resolve, postcodes, LAU regions, and a TypeScript SDK.
 - [movebank-api](https://github.com/movebank/movebank-api-doc) - Platform for animal tracking data. ![GitHub stars](https://img.shields.io/github/stars/movebank/movebank-api-doc?style=social)
 - [OpenAQ](https://openaq.org/) - Largest open-source air quality data platform.
 - [Open Charge Map API](https://openchargemap.org) - Public registry of electric vehicle charging locations.


### PR DESCRIPTION
## Summary

- Adds [Mapbase](https://mapbase.dev/) as a location registry API for turning coordinates into official locations, custom zones, hierarchy, geometry, and SEO-ready location context.

## Test plan

- [x] Entry follows the list existing format
- [x] Link points to https://mapbase.dev/