### PR TITLE
Add Działkopedia to Web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Plug-and-play geospatial web apps:
 
 - [city roads](https://anvaka.github.io/city-roads/) - Render every single road in any city at once. ![GitHub stars](https://img.shields.io/github/stars/anvaka/city-roads?style=social)
 - [Datawrapper](https://github.com/datawrapper/datawrapper) - Create charts, maps, and tables.
+- [Działkopedia](https://dzialkopedia.pl) - Browser-based Polish land-parcel checker: GUGiK cadastral/orthophoto, municipal zoning and transaction prices on an OpenStreetMap map.
 - [Fantasy Map Generator](https://github.com/Azgaar/Fantasy-Map-Generator) - Free web application for creating and editing fantasy maps. ![GitHub stars](https://img.shields.io/github/stars/Azgaar/Fantasy-Map-Generator?style=social)
 - [GeoLibre](https://github.com/opengeos/GeoLibre) - A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens. ![GitHub stars](https://img.shields.io/github/stars/opengeos/GeoLibre?style=social)
 - [geotiff.io](http://app.geotiff.io/) - Provides quick access to easy-to-use raster processing.


### PR DESCRIPTION
Adds Działkopedia (https://dzialkopedia.pl) under Web apps. A browser-based Polish land-parcel checker built on OpenStreetMap tiles with GUGiK cadastral/orthophoto, municipal zoning and RCN transaction prices. Thanks for maintaining the list.