### PR TITLE
Add Castlemap to Web maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A compilation of interesting web maps:
 - [ClimateArchive](https://climatearchive.org/) - An interactive visualisation of climate model data across time and space.
 - [Old Maps Online](https://www.oldmapsonline.org/) - Browse historical places and search for old maps with timeline.
 - [chronotrains](https://www.chronotrains.com) - Where can you go by train in 8h?
+- [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
 
 ## 🌐 Web apps 
 Plug-and-play geospatial web apps:


### PR DESCRIPTION
Follow-up to #38, as requested - one line added to the bottom of the Web maps section, guidelines format.

Castlemap is a free interactive night-map of the world's 2,400 great castles, fortresses and palaces - each with a photo, founding century and its story. Fully open stack (MapLibre GL JS + OpenFreeMap tiles) and open data (Wikidata + Wikimedia Commons); the dataset behind it is CC0 (GeoJSON/CSV, Zenodo DOI 10.5281/zenodo.21322360).

One transparency note on the guidelines: the site launched July 2026, so it isn't "a few months old" yet - the data and stack are all open, but if you'd rather see more track record first, no hard feelings: close this and I'll come back later in the year.