### PR TITLE
Add Europe Beach Map to Web maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ A compilation of interesting web maps:
 - [Old Maps Online](https://www.oldmapsonline.org/) - Browse historical places and search for old maps with timeline.
 - [chronotrains](https://www.chronotrains.com) - Where can you go by train in 8h?
 - [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
+- [Europe Beach Map](https://europebeachmap.com/) - Every notable European beach on one map, with sea temperature, sand and best season for each.
 
 ## 🌐 Web apps 
 Plug-and-play geospatial web apps:


### PR DESCRIPTION
Adds **Europe Beach Map** (https://europebeachmap.com) to **Web maps**, alongside the existing Castlemap entry — a d3-geo interactive map of 511 European beaches with sea temperature, sand and best season for each. No tiles; Natural Earth basemap, open dataset (CC BY 4.0).

Disclosure: I'm the maker (I also made the Castlemap entry already listed here).