### PR TITLE
Add Detourmap to Web maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A compilation of interesting web maps:
 - [chronotrains](https://www.chronotrains.com) - Where can you go by train in 8h?
 - [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
 - [Europe Beach Map](https://europebeachmap.com/) - Every notable European beach on one map, with sea temperature, sand and best season for each.
+- [Detourmap](https://detourmap.com/) - 70,343 places worth a detour — ruins, caves, waterfalls, castles and ghost towns — on one world map, built from Wikidata.
 
 ## 🌐 Web apps 
 Plug-and-play geospatial web apps:


### PR DESCRIPTION
Adds [Detourmap](https://detourmap.com/) to the Web maps section: a free interactive world map of 70,343 notable places (16 kinds — ruins, caves, waterfalls, castles, ghost towns — filterable by fame), built from Wikidata (CC0) and rendered with MapLibre GL on OpenFreeMap vector tiles. No ads, no signup; the dataset is also open (CC0) at https://github.com/Flightmussy/detourmap-places.

Same family as Castlemap and Europe Beach Map, already in this section.