### PR TITLE
Add Planetary Atlas to Web maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ A compilation of interesting web maps:
 - [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
 - [Europe Beach Map](https://europebeachmap.com/) - Every notable European beach on one map, with sea temperature, sand and best season for each.
 - [Detourmap](https://detourmap.com/) - 70,343 places worth a detour — ruins, caves, waterfalls, castles and ghost towns — on one world map, built from Wikidata.
+- [Planetary Atlas](https://planetatlas.org) - Zoomable maps of 14 worlds built from open NASA, USGS, ESA and JAXA imagery, with the IAU nomenclature and 69 surface mission landing sites.
 
 ## 🌐 Web apps 
 Plug-and-play geospatial web apps:


### PR DESCRIPTION
Adds [Planetary Atlas](https://planetatlas.org) to **Web maps**.

A browser-based zoomable atlas of 14 worlds — four planets, seven moons, Ceres and two asteroids — built from open agency imagery (NASA, USGS, ESA, JAXA, CNSA). 830 imagery layers, the full IAU nomenclature at 15,025 named features, and 69 surface mission landing sites. Resolution runs from global basemaps down to 26 cm/px over the Apollo 11 descent stage. CesiumJS under the hood, with a real per-body solar terminator rather than Earth's.

Two things worth stating plainly so you can judge it:

- **It launched this week.** The imagery pipeline and catalogue are substantial, but the site itself is new, and your guidelines ask for well-established entries. Entirely your call whether that disqualifies it for now.
- **The source isn't public**, though the site is free with no account and every layer is open agency data with its licence shown in-app. I read the "open" requirement as scoped to libraries and APIs, since Web maps already lists closed projects like ShadeMap, chronotrains and the NYT building map — but happy to be corrected.

Appended at the end of the section to match how Web maps is actually ordered. New branch as per CONTRIBUTING.