### PR TITLE
Update Detourmap entry: the map is nature and archaeology now

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ A compilation of interesting web maps:
 - [chronotrains](https://www.chronotrains.com) - Where can you go by train in 8h?
 - [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
 - [Europe Beach Map](https://europebeachmap.com/) - Every notable European beach on one map, with sea temperature, sand and best season for each.
-- [Detourmap](https://detourmap.com/) - 70,343 places worth a detour — ruins, caves, waterfalls, castles and ghost towns — on one world map, built from Wikidata.
+- [Detourmap](https://detourmap.com/) - Waterfalls, caves, volcanoes and lonely coasts, plus the ruins, tombs, ghost towns and shipwrecks people left behind, on one world map, built from Wikidata.
 
 ## 🌐 Web apps 
 Plug-and-play geospatial web apps:


### PR DESCRIPTION
Hi, thanks for merging Detourmap back in July (#41). The site has changed enough since that the entry no longer describes it, so this is a one line correction from the maker.

On 16 August the map was narrowed to two layers, nature and archaeology. Castles, churches, museums, gardens and theme parks are no longer on it, and the place count went from ~70k to ~41k. The current line promises castles, so anyone following it lands somewhere else than they expect.

The replacement deliberately carries no number. The count has already moved twice and this avoids the entry going stale a third time.
