### PR TITLE
Update Castlemap entry: 2,400 -> 7,044 landmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ A compilation of interesting web maps:
 - [ClimateArchive](https://climatearchive.org/) - An interactive visualisation of climate model data across time and space.
 - [Old Maps Online](https://www.oldmapsonline.org/) - Browse historical places and search for old maps with timeline.
 - [chronotrains](https://www.chronotrains.com) - Where can you go by train in 8h?
-- [Castlemap](https://thecastlemap.com/) - The world's 2,400 great castles on one night map, built from Wikidata.
+- [Castlemap](https://thecastlemap.com/) - The world's 7,044 great castles, fortresses and palaces on one night map, built from Wikidata.
 - [Europe Beach Map](https://europebeachmap.com/) - Every notable European beach on one map, with sea temperature, sand and best season for each.
 - [Detourmap](https://detourmap.com/) - 70,343 places worth a detour — ruins, caves, waterfalls, castles and ghost towns — on one world map, built from Wikidata.
 


### PR DESCRIPTION
The Castlemap entry has gone stale. The atlas listed 2,400 landmarks when it was added; it is at 7,044 across 141 countries today, and the entry now also names fortresses and palaces, which it covers alongside castles.

Verifiable from the site itself: https://thecastlemap.com/statistics/ and the CC0 download at https://thecastlemap.com/data/ (7,044 rows).

Disclosure: I maintain Castlemap. This is a correction to an existing entry, not a new addition.